### PR TITLE
To support text/xml, charset=UTF-8 feeds

### DIFF
--- a/morss/morss.py
+++ b/morss/morss.py
@@ -363,7 +363,10 @@ def FeedFetch(url, options):
         feed = feedify.Builder(url, xml, rule)
         feed.build()
         rss = feed.feed
-
+        
+    elseif ('contenttype == text/xml, charset=UTF-8'):
+        rss = feeds.parse(xml)
+        
     else:
         log('random page')
         log(contenttype)


### PR DESCRIPTION
To support text/xml, charset=UTF-8 feeds
Tested against:
* https://www.elblogsalmon.com/tag/rss/rss2.xml
* https://www.elblogsalmon.com/tag/rss/rss2.xml